### PR TITLE
CLA-006-get-claim

### DIFF
--- a/src/main/java/com/claims/claimsrestapi/controller/ClaimController.java
+++ b/src/main/java/com/claims/claimsrestapi/controller/ClaimController.java
@@ -5,10 +5,7 @@ import com.claims.claimsrestapi.service.ClaimService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @AllArgsConstructor
 @RestController
@@ -22,6 +19,13 @@ public class ClaimController {
     public ResponseEntity<ClaimDto> createClaim(@RequestBody ClaimDto claimDto){
         ClaimDto savedClaim = claimService.createClaim(claimDto);
         return new ResponseEntity<>(savedClaim, HttpStatus.CREATED);
+    }
+
+    //Build Add Claim ReST API
+    @GetMapping("{id}")
+    public ResponseEntity<ClaimDto> getClaimById(@PathVariable("id") Long claimId){
+        ClaimDto claimDto = claimService.getClaimById(claimId);
+        return ResponseEntity.ok(claimDto);
     }
 
 }

--- a/src/main/java/com/claims/claimsrestapi/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/claims/claimsrestapi/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package com.claims.claimsrestapi.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException{
+
+    public ResourceNotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/claims/claimsrestapi/service/ClaimService.java
+++ b/src/main/java/com/claims/claimsrestapi/service/ClaimService.java
@@ -4,4 +4,6 @@ import com.claims.claimsrestapi.dto.ClaimDto;
 
 public interface ClaimService {
     ClaimDto createClaim(ClaimDto claimDto);
+
+    ClaimDto getClaimById(Long claimId);
 }

--- a/src/main/java/com/claims/claimsrestapi/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/com/claims/claimsrestapi/service/impl/ClaimServiceImpl.java
@@ -2,6 +2,7 @@ package com.claims.claimsrestapi.service.impl;
 
 import com.claims.claimsrestapi.dto.ClaimDto;
 import com.claims.claimsrestapi.entity.Claim;
+import com.claims.claimsrestapi.exception.ResourceNotFoundException;
 import com.claims.claimsrestapi.mapper.ClaimMapper;
 import com.claims.claimsrestapi.repository.ClaimRepository;
 import com.claims.claimsrestapi.service.ClaimService;
@@ -20,5 +21,14 @@ public class ClaimServiceImpl implements ClaimService {
         Claim claim = ClaimMapper.mapToClaim(claimDto);
         Claim savedClaim = claimRepository.save(claim);
         return ClaimMapper.mapToClaimDto(savedClaim);
+    }
+
+    @Override
+    public ClaimDto getClaimById(Long claimId) {
+        Claim claim = claimRepository.findById(claimId)
+                .orElseThrow(() ->
+                        new ResourceNotFoundException("Claim does not exist with given id: " + claimId));
+
+        return ClaimMapper.mapToClaimDto(claim);
     }
 }

--- a/src/test/java/com/claims/claimsrestapi/controller/ClaimControllerTest.java
+++ b/src/test/java/com/claims/claimsrestapi/controller/ClaimControllerTest.java
@@ -1,6 +1,7 @@
 package com.claims.claimsrestapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
@@ -40,5 +41,19 @@ class ClaimControllerTest {
         assertEquals(HttpStatus.CREATED, responseEntity.getStatusCode()); // verify the status code
         assertEquals(savedClaimDto, responseEntity.getBody()); // verify that the response body matches the saved claim
         verify(claimService, times(1)).createClaim(any(ClaimDto.class)); // verify that claimService.createClaim was called once with any ClaimDto object
+    }
+
+    @Test
+    void testGetClaim() {
+        // Given
+        Long claimId = 1L;
+
+        // When
+        ResponseEntity<ClaimDto> responseEntity = claimController.getClaimById(claimId);
+
+        // Then
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertNull(responseEntity.getBody());
+        verify(claimService).getClaimById(claimId);
     }
 }

--- a/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
+++ b/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
@@ -1,13 +1,11 @@
 package com.claims.claimsrestapi.service.impl;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import com.claims.claimsrestapi.dto.ClaimDto;
 import com.claims.claimsrestapi.entity.Claim;
+import com.claims.claimsrestapi.exception.ResourceNotFoundException;
 import com.claims.claimsrestapi.mapper.ClaimMapper;
 import com.claims.claimsrestapi.repository.ClaimRepository;
 import org.junit.jupiter.api.Test;
@@ -16,6 +14,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class ClaimServiceImplTest {
@@ -39,5 +39,33 @@ class ClaimServiceImplTest {
         // Then
         assertTrue(new ReflectionEquals(claimDto).matches(result)); // verify that the result matches the input claimDto
         verify(claimRepository, times(1)).save(any(Claim.class)); // verify that claimRepository.save was called once with any Claim object
+    }
+
+    @Test
+    void testGetClaimById_ExistingClaim() {
+        // Given
+        Long claimId = 1L;
+        Claim claim = new Claim();
+        claim.setId(claimId); // set a dummy claim's Id to claimId
+        when(claimRepository.findById(claimId)).thenReturn(Optional.of(claim)); // When findById is called using claimId, return an Optional containing the specified claim
+
+        // When
+        ClaimDto result = claimService.getClaimById(claimId);
+
+        // Then
+        assertNotNull(result); // Assert that a Dto has been mapped with a nonnull result
+        assertEquals(claimId, result.getId()); // Assert that the id of the result matches the dummy claim's id
+        verify(claimRepository, times(1)).findById(claimId); // Verify that findById was invoked once
+    }
+
+    @Test
+    void testGetClaimById_NonExistingClaim() {
+        // Given
+        Long claimId = 1L;
+        when(claimRepository.findById(claimId)).thenReturn(Optional.empty()); // Return an empty Optional as a dummy claim has not been instantiated
+
+        // When & Then
+        assertThrows(ResourceNotFoundException.class, () -> claimService.getClaimById(claimId)); // Assert that an exception has been thrown due to the claim service not finding a claim with the provided claimId
+        verify(claimRepository, times(1)).findById(claimId); // Verify that findById was invoked once
     }
 }


### PR DESCRIPTION
## What?
This MR covers get feature being added to the claim system.
## Why?
This feature is being implemented to meet read (get) requirements.
## How?
Controller has had a method 'getClaimById' added which takes a claim ID number, passes it to ClaimService.getClaimById, and returns a response depending on the context of the ID. Claim Service uses an implementation to check the database for the given ID and feeds a response back to the controller. If the claim does not exist, an exception is thrown. If it is, the service will map the found  claim to a Dto and return it to the controller. This exception has been added in the form of a ResourceNotFoundException, which extends a RuntimeException. As inferred, this exception will be thrown when the resource is not found via the given ID.
## Testing?
Unit tests have been added for the controller to test that the finding of a claim by ID was called once with the correct ID, and that the response expected matches the actual result. A check for the Dto being null is also checked just to make sure that no writing is happening at this step. Unit tests for the ClaimService have also been added to make sure that the actual outcomes are happening as expected when the repository is given a claim and when the repository does not have a claim.