### PR TITLE
CLA-007-get-all-claims

### DIFF
--- a/src/main/java/com/claims/claimsrestapi/controller/ClaimController.java
+++ b/src/main/java/com/claims/claimsrestapi/controller/ClaimController.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/claims")
@@ -21,11 +23,18 @@ public class ClaimController {
         return new ResponseEntity<>(savedClaim, HttpStatus.CREATED);
     }
 
-    //Build Add Claim ReST API
+    //Build Get Claim ReST API
     @GetMapping("{id}")
     public ResponseEntity<ClaimDto> getClaimById(@PathVariable("id") Long claimId){
         ClaimDto claimDto = claimService.getClaimById(claimId);
         return ResponseEntity.ok(claimDto);
+    }
+
+    //Build Get All Claims ReST API
+    @GetMapping
+    public ResponseEntity<List<ClaimDto>> getAllClaims(){
+        List<ClaimDto> claims = claimService.getAllClaims();
+        return ResponseEntity.ok(claims);
     }
 
 }

--- a/src/main/java/com/claims/claimsrestapi/service/ClaimService.java
+++ b/src/main/java/com/claims/claimsrestapi/service/ClaimService.java
@@ -2,8 +2,12 @@ package com.claims.claimsrestapi.service;
 
 import com.claims.claimsrestapi.dto.ClaimDto;
 
+import java.util.List;
+
 public interface ClaimService {
     ClaimDto createClaim(ClaimDto claimDto);
 
     ClaimDto getClaimById(Long claimId);
+
+    List<ClaimDto> getAllClaims();
 }

--- a/src/main/java/com/claims/claimsrestapi/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/com/claims/claimsrestapi/service/impl/ClaimServiceImpl.java
@@ -9,6 +9,8 @@ import com.claims.claimsrestapi.service.ClaimService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @AllArgsConstructor
 public class ClaimServiceImpl implements ClaimService {
@@ -30,5 +32,13 @@ public class ClaimServiceImpl implements ClaimService {
                         new ResourceNotFoundException("Claim does not exist with given id: " + claimId));
 
         return ClaimMapper.mapToClaimDto(claim);
+    }
+
+    @Override
+    public List<ClaimDto> getAllClaims() {
+        List<Claim> claims = claimRepository.findAll();
+        return claims.stream()
+                .map(ClaimMapper::mapToClaimDto)
+                .toList();
     }
 }

--- a/src/test/java/com/claims/claimsrestapi/controller/ClaimControllerTest.java
+++ b/src/test/java/com/claims/claimsrestapi/controller/ClaimControllerTest.java
@@ -15,7 +15,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class ClaimControllerTest {
@@ -25,7 +35,6 @@ class ClaimControllerTest {
 
     @InjectMocks
     private ClaimController claimController;
-
 
     @Test
     void testCreateClaim() {
@@ -55,5 +64,32 @@ class ClaimControllerTest {
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertNull(responseEntity.getBody());
         verify(claimService).getClaimById(claimId);
+    }
+
+    @Test
+    void testGetAllClaims() throws Exception {
+        // Given
+        List<ClaimDto> mockClaims = new ArrayList<>();
+        ClaimDto claim1 = new ClaimDto();
+        claim1.setId(1L);
+        mockClaims.add(claim1);
+        ClaimDto claim2 = new ClaimDto();
+        claim2.setId(2L);
+        mockClaims.add(claim2);
+
+        when(claimService.getAllClaims()).thenReturn(mockClaims); // Mocking claimService.getAllClaims() to return mockClaims
+
+        // Setting up MockMvc
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(claimController).build();
+
+        // When & Then
+        mockMvc.perform(get("/api/claims")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.size()").value(mockClaims.size()))
+                .andExpect(jsonPath("$[0].id").value(claim1.getId()))
+                .andExpect(jsonPath("$[1].id").value(claim2.getId()));
+        verify(claimService, times(1)).getAllClaims(); // Verifying that getAllClaims method of claimService is called exactly once
     }
 }

--- a/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
+++ b/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
@@ -15,6 +15,8 @@ import org.mockito.Mock;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,5 +69,29 @@ class ClaimServiceImplTest {
         // When & Then
         assertThrows(ResourceNotFoundException.class, () -> claimService.getClaimById(claimId)); // Assert that an exception has been thrown due to the claim service not finding a claim with the provided claimId
         verify(claimRepository, times(1)).findById(claimId); // Verify that findById was invoked once
+    }
+
+    @Test
+    void testGetAllClaims() {
+        // Given
+        List<Claim> mockClaims = new ArrayList<>();
+        Claim claim1 = new Claim();
+        claim1.setId(1L);
+        mockClaims.add(claim1);
+        Claim claim2 = new Claim();
+        claim2.setId(2L);
+        mockClaims.add(claim2);
+
+        when(claimRepository.findAll()).thenReturn(mockClaims); // Mocking claimRepository.findAll() to return mockClaims
+
+        // When
+        List<ClaimDto> result = claimService.getAllClaims(); // Calling the method under test
+
+        // Then
+        assertNotNull(result); // Asserting that the result is not null
+        assertEquals(2, result.size()); // Asserting that the size of the result list is 2
+        assertEquals(1L, result.get(0).getId()); // Asserting the first claim ID in the result list
+        assertEquals(2L, result.get(1).getId()); // Asserting the second claim ID in the result list
+        verify(claimRepository, times(1)).findAll(); // Verifying that findAll method of claimRepository is called exactly once
     }
 }


### PR DESCRIPTION
## What?
This MR covers get all (read all) feature being added to the claim system.
## Why?
This feature is being implemented to meet read (get) requirements.
## How?
Controller has had a method 'getAllClaims' added which creates a http request for all claims at the endpoint api/claims. Claim Service uses an implementation to check the database for all claims and returns them as a list to the controller.
## Testing?
Unit tests have been added for the controller to test that the finding of all claims was successfully, and that the response expected matches the actual result. Unit tests for the ClaimService have also been added to make sure that the actual outcomes are happening as expected when the repository is given multiple claims.