### PR TITLE
CLA-009-delete-claim

### DIFF
--- a/src/main/java/com/claims/claimsrestapi/controller/ClaimController.java
+++ b/src/main/java/com/claims/claimsrestapi/controller/ClaimController.java
@@ -44,4 +44,11 @@ public class ClaimController {
         ClaimDto claimDto = claimService.updateClaim(claimId, updatedClaim);
         return ResponseEntity.ok(claimDto);
     }
+
+    // Build Delete Claim ReST API
+    @DeleteMapping("{id}")
+    public ResponseEntity<String> deleteClaim(@PathVariable("id") Long claimID){
+        claimService.deleteClaim(claimID);
+        return ResponseEntity.ok("Claim deleted successfully.");
+    }
 }

--- a/src/main/java/com/claims/claimsrestapi/service/ClaimService.java
+++ b/src/main/java/com/claims/claimsrestapi/service/ClaimService.java
@@ -12,4 +12,6 @@ public interface ClaimService {
     List<ClaimDto> getAllClaims();
 
     ClaimDto updateClaim(Long claimId, ClaimDto updatedClaim);
+
+    void deleteClaim(Long claimId);
 }

--- a/src/main/java/com/claims/claimsrestapi/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/com/claims/claimsrestapi/service/impl/ClaimServiceImpl.java
@@ -60,4 +60,13 @@ public class ClaimServiceImpl implements ClaimService {
 
         return ClaimMapper.mapToClaimDto(updatedClaimObj);
     }
+
+    @Override
+    public void deleteClaim(Long claimId) {
+        claimRepository.findById(claimId).orElseThrow(
+                () -> new ResourceNotFoundException("Claim does not exist with given ID: " + claimId)
+        );
+
+        claimRepository.deleteById((claimId));
+    }
 }

--- a/src/test/java/com/claims/claimsrestapi/controller/ClaimControllerTest.java
+++ b/src/test/java/com/claims/claimsrestapi/controller/ClaimControllerTest.java
@@ -2,12 +2,9 @@ package com.claims.claimsrestapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
 
 import com.claims.claimsrestapi.dto.ClaimDto;
+import com.claims.claimsrestapi.exception.ResourceNotFoundException;
 import com.claims.claimsrestapi.service.ClaimService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +16,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -92,10 +91,6 @@ class ClaimControllerTest {
                 .andExpect(jsonPath("$[0].id").value(claim1.getId()))
                 .andExpect(jsonPath("$[1].id").value(claim2.getId()));
         verify(claimService, times(1)).getAllClaims(); // Verifying that getAllClaims method of claimService is called exactly once
-
-        ResponseEntity<List<ClaimDto>> responseEntity = claimController.getAllClaims();
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-        assertEquals(mockClaims, responseEntity.getBody());
     }
 
     @Test
@@ -119,5 +114,19 @@ class ClaimControllerTest {
         // Then
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertEquals(mockClaimDto, responseEntity.getBody());
+    }
+
+    @Test
+    void testDeleteClaim() {
+        // Given
+        Long claimId = 1L;
+
+        // When
+        ResponseEntity<String> responseEntity = claimController.deleteClaim(claimId);
+
+        // Then
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals("Claim deleted successfully.", responseEntity.getBody());
+        verify(claimService, times(1)).deleteClaim(claimId);
     }
 }

--- a/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
+++ b/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
@@ -210,4 +210,28 @@ class ClaimServiceImplTest {
         verify(claimRepository, times(1)).findById(claimId); // Verify that findById was invoked once
         verify(claimRepository, never()).save(any());
     }
+
+    @Test
+    void testDeleteClaim_Success() {
+        // Given
+        Long claimId = 1L;
+        when(claimRepository.findById(claimId)).thenReturn(java.util.Optional.of(new Claim()));
+
+        // When
+        claimService.deleteClaim(claimId);
+
+        // Then
+        verify(claimRepository, times(1)).deleteById(claimId);
+    }
+
+    @Test
+    void testDeleteClaim_ClaimNotFound() {
+        // Given
+        Long claimId = 1L;
+        when(claimRepository.findById(claimId)).thenReturn(java.util.Optional.empty());
+
+        // When & Then
+        assertThrows(ResourceNotFoundException.class, () -> claimService.deleteClaim(claimId));
+        verify(claimRepository, never()).deleteById(claimId);
+    }
 }


### PR DESCRIPTION
## What?
This MR covers delete functionality being added to the claim system.
## Why?
This feature is being implemented to meet delete requirements as part of the CRUD assignment.
## How?
Delete added to ClaimController to find an entry in the database via id. Service and implementation added to delete the found entry as long as the entry exists.
## Testing?
Unit Test Coverage added for all methods.