### PR TITLE
CLA-012-note-dto-and-mapper

### DIFF
--- a/src/main/java/com/claims/claimsrestapi/dto/NoteDto.java
+++ b/src/main/java/com/claims/claimsrestapi/dto/NoteDto.java
@@ -1,0 +1,19 @@
+package com.claims.claimsrestapi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoteDto {
+    private Long id;
+    private String content;
+    private Date createdDateTime;
+    private Date updatedDateTime;
+}

--- a/src/main/java/com/claims/claimsrestapi/mapper/NoteMapper.java
+++ b/src/main/java/com/claims/claimsrestapi/mapper/NoteMapper.java
@@ -1,0 +1,25 @@
+package com.claims.claimsrestapi.mapper;
+
+import com.claims.claimsrestapi.dto.NoteDto;
+import com.claims.claimsrestapi.entity.Note;
+
+public class NoteMapper {
+
+    public static NoteDto mapToNoteDto(Note note){
+        return new NoteDto(
+                note.getId(),
+                note.getContent(),
+                note.getCreatedDateTime(),
+                note.getUpdatedDateTime()
+        );
+    }
+
+    public static Note mapToNote(NoteDto noteDto){
+        return new Note(
+                noteDto.getId(),
+                noteDto.getContent(),
+                noteDto.getCreatedDateTime(),
+                noteDto.getUpdatedDateTime()
+        );
+    }
+}


### PR DESCRIPTION
## What?
This MR covers note dto and note mapper being added to the claim system.
## Why?
As part of the CRUD assignment, Note dto and mapper is needed fo CRUD functionality. DTOs are in place to have data from a database mapped to them.
## How?
NoteMapper and NoteDto classes have been created and populated with necessary code for functionality.
## Testing?
Unit test coverage will be included as functionality is added for note.