### PR TITLE
CLA-014-get-note

### DIFF
--- a/src/main/java/com/claims/claimsrestapi/controller/NoteController.java
+++ b/src/main/java/com/claims/claimsrestapi/controller/NoteController.java
@@ -5,10 +5,7 @@ import com.claims.claimsrestapi.service.NoteService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @AllArgsConstructor
 @RestController
@@ -22,5 +19,12 @@ public class NoteController {
     public ResponseEntity<NoteDto> createNote(@RequestBody NoteDto noteDto) {
         NoteDto savedNote = noteService.createNote(noteDto);
         return new ResponseEntity<>(savedNote, HttpStatus.CREATED);
+    }
+
+    //Build Get Note ReST API
+    @GetMapping("{id}")
+    public ResponseEntity<NoteDto> getNoteById(@PathVariable("id") Long noteId){
+        NoteDto noteDto = noteService.getNoteById(noteId);
+        return ResponseEntity.ok(noteDto);
     }
 }

--- a/src/main/java/com/claims/claimsrestapi/service/NoteService.java
+++ b/src/main/java/com/claims/claimsrestapi/service/NoteService.java
@@ -4,4 +4,6 @@ import com.claims.claimsrestapi.dto.NoteDto;
 
 public interface NoteService {
     NoteDto createNote(NoteDto noteDto);
+    NoteDto getNoteById(Long noteId);
+
 }

--- a/src/main/java/com/claims/claimsrestapi/service/impl/NoteServiceImpl.java
+++ b/src/main/java/com/claims/claimsrestapi/service/impl/NoteServiceImpl.java
@@ -2,6 +2,7 @@ package com.claims.claimsrestapi.service.impl;
 
 import com.claims.claimsrestapi.dto.NoteDto;
 import com.claims.claimsrestapi.entity.Note;
+import com.claims.claimsrestapi.exception.ResourceNotFoundException;
 import com.claims.claimsrestapi.mapper.NoteMapper;
 import com.claims.claimsrestapi.repository.NoteRepository;
 import com.claims.claimsrestapi.service.NoteService;
@@ -20,5 +21,14 @@ public class NoteServiceImpl implements NoteService {
         Note note = NoteMapper.mapToNote(noteDto);
         Note savedNote = noteRepository.save(note);
         return NoteMapper.mapToNoteDto(savedNote);
+    }
+
+    @Override
+    public NoteDto getNoteById(Long noteId) {
+        Note note = noteRepository.findById(noteId)
+                .orElseThrow(() ->
+                        new ResourceNotFoundException("Note does not exist with given id: " + noteId));
+
+        return NoteMapper.mapToNoteDto(note);
     }
 }

--- a/src/test/java/com/claims/claimsrestapi/controller/NoteControllerTest.java
+++ b/src/test/java/com/claims/claimsrestapi/controller/NoteControllerTest.java
@@ -1,6 +1,7 @@
 package com.claims.claimsrestapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
@@ -40,5 +41,19 @@ class NoteControllerTest {
         assertEquals(HttpStatus.CREATED, responseEntity.getStatusCode()); // verify the status code
         assertEquals(savedNoteDto, responseEntity.getBody()); // verify that the response body matches the saved claim
         verify(noteService, times(1)).createNote(any(NoteDto.class)); // verify that claimService.createClaim was called once with any ClaimDto object
+    }
+
+    @Test
+    void testGetNote() {
+        // Given
+        Long noteId = 1L;
+
+        // When
+        ResponseEntity<NoteDto> responseEntity = noteController.getNoteById(noteId);
+
+        // Then
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertNull(responseEntity.getBody());
+        verify(noteService).getNoteById(noteId);
     }
 }

--- a/src/test/java/com/claims/claimsrestapi/service/impl/NoteServiceImplTest.java
+++ b/src/test/java/com/claims/claimsrestapi/service/impl/NoteServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.claims.claimsrestapi.service.impl;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 
 import com.claims.claimsrestapi.dto.NoteDto;
 import com.claims.claimsrestapi.entity.Note;
+import com.claims.claimsrestapi.exception.ResourceNotFoundException;
 import com.claims.claimsrestapi.mapper.NoteMapper;
 import com.claims.claimsrestapi.repository.NoteRepository;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class NoteServiceImplTest {
@@ -39,5 +42,33 @@ class NoteServiceImplTest {
         // Then
         assertTrue(new ReflectionEquals(noteDto).matches(result)); // verify that the result matches the input noteDto
         verify(noteRepository, times(1)).save(any(Note.class)); // verify that noteRepository.save was called once with any Note object
+    }
+
+    @Test
+    void testGetNoteById_ExistingNote() {
+        // Given
+        Long noteId = 1L;
+        Note note = new Note();
+        note.setId(noteId); // set a dummy note's Id to noteId
+        when(noteRepository.findById(noteId)).thenReturn(Optional.of(note)); // When findById is called using noteId, return an Optional containing the specified note
+
+        // When
+        NoteDto result = noteService.getNoteById(noteId);
+
+        // Then
+        assertNotNull(result); // Assert that a Dto has been mapped with a nonnull result
+        assertEquals(noteId, result.getId()); // Assert that the id of the result matches the dummy note's id
+        verify(noteRepository, times(1)).findById(noteId); // Verify that findById was invoked once
+    }
+
+    @Test
+    void testGetNoteById_NonExistingNote() {
+        // Given
+        Long noteId = 1L;
+        when(noteRepository.findById(noteId)).thenReturn(Optional.empty()); // Return an empty Optional as a dummy note has not been instantiated
+
+        // When & Then
+        assertThrows(ResourceNotFoundException.class, () -> noteService.getNoteById(noteId)); // Assert that an exception has been thrown due to the note service not finding a note with the provided noteId
+        verify(noteRepository, times(1)).findById(noteId); // Verify that findById was invoked once
     }
 }


### PR DESCRIPTION
## What?
This is Read functionality.
## Why?
Ticks off the R in CRUD for Notes.
## How?
Same as last MR except get mapping with read functionality instead of create functionality. Uses id for search.
## Testing?
Unit test coverage implemented.