### PR TITLE
CLA-017-delete-note

### DIFF
--- a/src/main/java/com/claims/claimsrestapi/controller/NoteController.java
+++ b/src/main/java/com/claims/claimsrestapi/controller/NoteController.java
@@ -44,4 +44,11 @@ public class NoteController {
         NoteDto noteDto = noteService.updateNote(noteId, updatedNote);
         return ResponseEntity.ok(noteDto);
     }
+
+    // Build Delete Note ReST API
+    @DeleteMapping("{id}")
+    public ResponseEntity<String> deleteNote(@PathVariable("id") Long noteID){
+        noteService.deleteNote(noteID);
+        return ResponseEntity.ok("Note deleted successfully.");
+    }
 }

--- a/src/main/java/com/claims/claimsrestapi/service/NoteService.java
+++ b/src/main/java/com/claims/claimsrestapi/service/NoteService.java
@@ -9,4 +9,5 @@ public interface NoteService {
     NoteDto getNoteById(Long noteId);
     List<NoteDto> getAllNotes();
     NoteDto updateNote(Long noteId, NoteDto updatedNote);
+    void deleteNote(Long noteId);
 }

--- a/src/main/java/com/claims/claimsrestapi/service/impl/NoteServiceImpl.java
+++ b/src/main/java/com/claims/claimsrestapi/service/impl/NoteServiceImpl.java
@@ -59,4 +59,13 @@ public class NoteServiceImpl implements NoteService {
 
         return NoteMapper.mapToNoteDto(updatedNoteObj);
     }
+
+    @Override
+    public void deleteNote(Long noteId) {
+        noteRepository.findById(noteId).orElseThrow(
+                () -> new ResourceNotFoundException("Note does not exist with given ID: " + noteId)
+        );
+
+        noteRepository.deleteById((noteId));
+    }
 }

--- a/src/test/java/com/claims/claimsrestapi/controller/ClaimControllerTest.java
+++ b/src/test/java/com/claims/claimsrestapi/controller/ClaimControllerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.claims.claimsrestapi.dto.ClaimDto;
-import com.claims.claimsrestapi.exception.ResourceNotFoundException;
 import com.claims.claimsrestapi.service.ClaimService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,12 +76,13 @@ class ClaimControllerTest {
         claim2.setId(2L);
         mockClaims.add(claim2);
 
+        // When
         when(claimService.getAllClaims()).thenReturn(mockClaims); // Mocking claimService.getAllClaims() to return mockClaims
 
         // Setting up MockMvc
         MockMvc mockMvc = MockMvcBuilders.standaloneSetup(claimController).build();
 
-        // When & Then
+        // Then
         mockMvc.perform(get("/api/claims")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/com/claims/claimsrestapi/controller/NoteControllerTest.java
+++ b/src/test/java/com/claims/claimsrestapi/controller/NoteControllerTest.java
@@ -78,12 +78,13 @@ class NoteControllerTest {
         note2.setId(2L);
         mockNotes.add(note2);
 
+        // When
         when(noteService.getAllNotes()).thenReturn(mockNotes); // Mocking noteService.getAllNotes() to return mockNotes
 
         // Setting up MockMvc
         MockMvc mockMvc = MockMvcBuilders.standaloneSetup(noteController).build();
 
-        // When & Then
+        // Then
         mockMvc.perform(get("/api/notes")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -113,5 +114,19 @@ class NoteControllerTest {
         // Then
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertEquals(mockNoteDto, responseEntity.getBody());
+    }
+
+    @Test
+    void testDeleteNote() {
+        // Given
+        Long noteId = 1L;
+
+        // When
+        ResponseEntity<String> responseEntity = noteController.deleteNote(noteId);
+
+        // Then
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals("Note deleted successfully.", responseEntity.getBody());
+        verify(noteService, times(1)).deleteNote(noteId);
     }
 }

--- a/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
+++ b/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
@@ -228,10 +228,14 @@ class ClaimServiceImplTest {
     void testDeleteClaim_ClaimNotFound() {
         // Given
         Long claimId = 1L;
+
+        // When
         when(claimRepository.findById(claimId)).thenReturn(java.util.Optional.empty());
 
-        // When & Then
-        assertThrows(ResourceNotFoundException.class, () -> claimService.deleteClaim(claimId));
+        // Then
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> claimService.deleteClaim(claimId));
         verify(claimRepository, never()).deleteById(claimId);
     }
 }

--- a/src/test/java/com/claims/claimsrestapi/service/impl/NoteServiceImplTest.java
+++ b/src/test/java/com/claims/claimsrestapi/service/impl/NoteServiceImplTest.java
@@ -203,5 +203,30 @@ class NoteServiceImplTest {
         verify(noteRepository, never()).save(any());
     }
 
+    @Test
+    void testDeleteNote_Success() {
+        // Given
+        Long noteId = 1L;
+        when(noteRepository.findById(noteId)).thenReturn(java.util.Optional.of(new Note()));
 
+        // When
+        noteService.deleteNote(noteId);
+
+        // Then
+        verify(noteRepository, times(1)).deleteById(noteId);
+    }
+
+    @Test
+    void testDeleteNote_NoteNotFound() {
+        // Given
+        Long noteId = 1L;
+        // When
+        when(noteRepository.findById(noteId)).thenReturn(java.util.Optional.empty());
+
+        // Then
+        assertThrows(
+                ResourceNotFoundException.class, 
+                () -> noteService.deleteNote(noteId));
+        verify(noteRepository, never()).deleteById(noteId);
+    }
 }


### PR DESCRIPTION
## What?
This MR is for note delete functionality.
## Why?
D in CRUD is required as part of assignment.
## How?
Adds code to controller and service which work together through a DELETE request for a record (note) by ID and, if found, deletes the record. ## Testing?
Unit test coverage implemented.