### PR TITLE
CLA-018-non-update-created-time

### DIFF
--- a/src/main/java/com/claims/claimsrestapi/service/impl/ClaimServiceImpl.java
+++ b/src/main/java/com/claims/claimsrestapi/service/impl/ClaimServiceImpl.java
@@ -48,14 +48,18 @@ public class ClaimServiceImpl implements ClaimService {
         Claim claim = claimRepository.findById(claimId).orElseThrow(
                 () -> new ResourceNotFoundException("Claim does not exist with given ID: " + claimId)
         );
-        if(claim.getCreatedDateTime().after(updatedClaim.getUpdatedDateTime())){
+        if (claim.getCreatedDateTime().after(updatedClaim.getUpdatedDateTime())) {
             throw new CreatedAndUpdatedDateTimeException("UpdatedDateTime cannot be before CreatedDateTime");
         }
-        claim.setAmount(updatedClaim.getAmount());
-        claim.setStatus(updatedClaim.getStatus());
-        claim.setCreatedDateTime(updatedClaim.getCreatedDateTime());
-        claim.setUpdatedDateTime(updatedClaim.getUpdatedDateTime());
-
+        if (updatedClaim.getAmount() != null) {
+            claim.setAmount(updatedClaim.getAmount());
+        }
+        if (updatedClaim.getStatus() != null){
+            claim.setStatus(updatedClaim.getStatus());
+        }
+        if (updatedClaim.getUpdatedDateTime() != null) {
+            claim.setUpdatedDateTime(updatedClaim.getUpdatedDateTime());
+        }
         Claim updatedClaimObj = claimRepository.save(claim);
 
         return ClaimMapper.mapToClaimDto(updatedClaimObj);

--- a/src/main/java/com/claims/claimsrestapi/service/impl/NoteServiceImpl.java
+++ b/src/main/java/com/claims/claimsrestapi/service/impl/NoteServiceImpl.java
@@ -48,13 +48,15 @@ public class NoteServiceImpl implements NoteService {
         Note note = noteRepository.findById(noteId).orElseThrow(
                 () -> new ResourceNotFoundException("Note does not exist with given ID: " + noteId)
         );
-        if(note.getCreatedDateTime().after(updatedNote.getUpdatedDateTime())){
+        if (note.getCreatedDateTime().after(updatedNote.getUpdatedDateTime())) {
             throw new CreatedAndUpdatedDateTimeException("UpdatedDateTime cannot be before CreatedDateTime");
         }
-        note.setContent(updatedNote.getContent());
-        note.setCreatedDateTime(updatedNote.getCreatedDateTime());
-        note.setUpdatedDateTime(updatedNote.getUpdatedDateTime());
-
+        if (updatedNote.getContent() != null) {
+            note.setContent(updatedNote.getContent());
+        }
+        if (updatedNote.getUpdatedDateTime() != null) {
+            note.setUpdatedDateTime(updatedNote.getUpdatedDateTime());
+        }
         Note updatedNoteObj = noteRepository.save(note);
 
         return NoteMapper.mapToNoteDto(updatedNoteObj);

--- a/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
+++ b/src/test/java/com/claims/claimsrestapi/service/impl/ClaimServiceImplTest.java
@@ -111,13 +111,11 @@ class ClaimServiceImplTest {
         Long claimId = 1L;
 
         LocalDateTime localDateTime = LocalDateTime.now();
-        Date createdDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(1).toInstant());
         Date updatedDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
 
         ClaimDto updatedClaim = new ClaimDto();
         updatedClaim.setAmount(BigDecimal.valueOf(100.00));
         updatedClaim.setStatus("APPROVED");
-        updatedClaim.setCreatedDateTime(createdDateTime);
         updatedClaim.setUpdatedDateTime(updatedDateTime);
 
         Claim claim = new Claim();
@@ -137,7 +135,6 @@ class ClaimServiceImplTest {
         assertEquals(claimId, result.getId());
         assertEquals(updatedClaim.getAmount(), result.getAmount());
         assertEquals(updatedClaim.getStatus(), result.getStatus());
-        assertEquals(updatedClaim.getCreatedDateTime(), result.getCreatedDateTime());
         assertEquals(updatedClaim.getUpdatedDateTime(), result.getUpdatedDateTime());
 
         ArgumentCaptor<Claim> captor = ArgumentCaptor.forClass(Claim.class);
@@ -145,7 +142,6 @@ class ClaimServiceImplTest {
         assertEquals(claimId, captor.getValue().getId());
         assertEquals(updatedClaim.getAmount(), captor.getValue().getAmount());
         assertEquals(updatedClaim.getStatus(), captor.getValue().getStatus());
-        assertEquals(updatedClaim.getCreatedDateTime(), captor.getValue().getCreatedDateTime());
         assertEquals(updatedClaim.getUpdatedDateTime(), captor.getValue().getUpdatedDateTime());
     }
 
@@ -182,13 +178,11 @@ class ClaimServiceImplTest {
         Long claimId = 1L;
 
         LocalDateTime localDateTime = LocalDateTime.now();
-        Date createdDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
         Date updatedDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(4).toInstant());
 
         ClaimDto updatedClaim = new ClaimDto();
         updatedClaim.setAmount(BigDecimal.valueOf(100.00));
         updatedClaim.setStatus("APPROVED");
-        updatedClaim.setCreatedDateTime(createdDateTime);
         updatedClaim.setUpdatedDateTime(updatedDateTime);
 
         Claim claim = new Claim();

--- a/src/test/java/com/claims/claimsrestapi/service/impl/NoteServiceImplTest.java
+++ b/src/test/java/com/claims/claimsrestapi/service/impl/NoteServiceImplTest.java
@@ -110,18 +110,17 @@ class NoteServiceImplTest {
         Long noteId = 1L;
 
         LocalDateTime localDateTime = LocalDateTime.now();
-        Date createdDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(1).toInstant());
+        Date createdDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(3).toInstant());
         Date updatedDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
 
         NoteDto updatedNote = new NoteDto();
         updatedNote.setContent("Lorem ipsum dolor");
-        updatedNote.setCreatedDateTime(createdDateTime);
         updatedNote.setUpdatedDateTime(updatedDateTime);
 
         Note note = new Note();
         note.setId(noteId);
         note.setContent("Lorem ipsum");
-        note.setCreatedDateTime(Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(3).toInstant()));
+        note.setCreatedDateTime(createdDateTime);
         note.setUpdatedDateTime(Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(2).toInstant()));
 
         when(noteRepository.findById(noteId)).thenReturn(Optional.of(note));
@@ -133,14 +132,12 @@ class NoteServiceImplTest {
         // Then
         assertEquals(noteId, result.getId());
         assertEquals(updatedNote.getContent(), result.getContent());
-        assertEquals(updatedNote.getCreatedDateTime(), result.getCreatedDateTime());
         assertEquals(updatedNote.getUpdatedDateTime(), result.getUpdatedDateTime());
 
         ArgumentCaptor<Note> captor = ArgumentCaptor.forClass(Note.class);
         verify(noteRepository).save(captor.capture());
         assertEquals(noteId, captor.getValue().getId());
         assertEquals(updatedNote.getContent(), captor.getValue().getContent());
-        assertEquals(updatedNote.getCreatedDateTime(), captor.getValue().getCreatedDateTime());
         assertEquals(updatedNote.getUpdatedDateTime(), captor.getValue().getUpdatedDateTime());
     }
 
@@ -176,19 +173,18 @@ class NoteServiceImplTest {
         Long noteId = 1L;
 
         LocalDateTime localDateTime = LocalDateTime.now();
-        Date createdDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date createdDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(2).toInstant());
         Date updatedDateTime = Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(4).toInstant());
 
         NoteDto updatedNote = new NoteDto();
         updatedNote.setContent("Lorem ipsum dolor");
-        updatedNote.setCreatedDateTime(createdDateTime);
         updatedNote.setUpdatedDateTime(updatedDateTime);
 
         Note note = new Note();
         note.setId(noteId);
         note.setContent("Lorem ipsum");
-        note.setCreatedDateTime(Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(3).toInstant()));
-        note.setUpdatedDateTime(Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(2).toInstant()));
+        note.setCreatedDateTime(createdDateTime);
+        note.setUpdatedDateTime(Date.from(localDateTime.atZone(ZoneId.systemDefault()).minusDays(1).toInstant()));
 
         //  When
         when(noteRepository.findById(noteId)).thenReturn(Optional.of(note));


### PR DESCRIPTION
## What?
This MR is for note update functionality.
## Why?
As part of system's requirements, there would be no use case where the created time would need updating.
## How?
This has been amended so that created time will not be written over when doing a put request at an existing id. Furthermore, null checks have been added for each field that can be updated so that if a value is not passed, then the existing record will not write over these values with null. This has been added for claims and notes.
## Testing?
Unit test coverage not implemented for null scenarios as per this MR.